### PR TITLE
🐞[Bugfix]This potentially silences the BRSharedPrefs  lookup error

### DIFF
--- a/app/src/main/java/com/breadwallet/tools/manager/BRSharedPrefs.java
+++ b/app/src/main/java/com/breadwallet/tools/manager/BRSharedPrefs.java
@@ -38,14 +38,18 @@ public class BRSharedPrefs {
     }
 
     public static String getIso(Context context) {
+
         SharedPreferences settingsToGet = context.getSharedPreferences(BRConstants.PREFS_NAME, 0);
         String defIso;
         try {
             defIso = Currency.getInstance(Locale.getDefault()).getCurrencyCode();
         } catch (IllegalArgumentException e) {
             Timber.e(e);
-            defIso = Currency.getInstance(Locale.US).getCurrencyCode();
+            ///This is always going to be a Litewallet problem
+            // Inspired by: https://stackoverflow.com/questions/26376439/locale-getdefault-returns-unsuported-invalid-locale-for-currency-getinstance
+            defIso = Currency.getInstance(new Locale("en", "US")).getCurrencyCode();
         }
+
         return settingsToGet.getString(BRConstants.CURRENT_CURRENCY, defIso);
     }
 


### PR DESCRIPTION
## Explanation
Litewallet uses the users locale and their currency but the currency may not match.  So there is a soft fail.
At worst case it should simply default to USD….this is the update for that.
## Firebase:
 https://console.firebase.google.com/u/0/project/litewallet-beta/crashlytics/app/android:com.loafwallet/issues/c9ce04d68423ae25f0ee05f2d2e203fa?time=last-seven-days&sessionEventKey=626FCF7303B900017224281106C0856A_1671561729542858575
 
 ## Inspiration
https://stackoverflow.com/questions/26376439/locale-getdefault-returns-unsuported-invalid-locale-for-currency-getinstance
