### PR TITLE
🐜[Bugfix] Fragment fingerprint crash 125

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -64,7 +64,7 @@ android {
         applicationId = 'com.loafwallet'
         minSdkVersion 27 
         targetSdkVersion 32  
-        versionCode 723
+        versionCode 724
         versionName "v2.8.1"
         multiDexEnabled true
         archivesBaseName = "${versionName}(${versionCode})"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -64,8 +64,8 @@ android {
         applicationId = 'com.loafwallet'
         minSdkVersion 27 
         targetSdkVersion 32  
-        versionCode 722
-        versionName "v2.8.0"
+        versionCode 723
+        versionName "v2.8.1"
         multiDexEnabled true
         archivesBaseName = "${versionName}(${versionCode})"
 

--- a/app/src/main/java/com/breadwallet/presenter/fragments/FragmentFingerprint.java
+++ b/app/src/main/java/com/breadwallet/presenter/fragments/FragmentFingerprint.java
@@ -1,4 +1,5 @@
 package com.breadwallet.presenter.fragments;
+
 import android.animation.Animator;
 import android.animation.AnimatorListenerAdapter;
 import android.animation.ArgbEvaluator;
@@ -9,7 +10,6 @@ import android.content.Context;
 import android.hardware.fingerprint.FingerprintManager;
 import android.os.Bundle;
 import android.os.Handler;
-import androidx.annotation.Nullable;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -21,6 +21,8 @@ import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
+import androidx.annotation.Nullable;
+
 import com.breadwallet.R;
 import com.breadwallet.presenter.activities.BreadActivity;
 import com.breadwallet.presenter.interfaces.BRAuthCompletion;
@@ -29,6 +31,8 @@ import com.breadwallet.tools.animation.DecelerateOvershootInterpolator;
 import com.breadwallet.tools.security.AuthManager;
 import com.breadwallet.tools.security.FingerprintUiHelper;
 import com.breadwallet.tools.util.Utils;
+
+import timber.log.Timber;
 
 /**
  * A dialog which uses fingerprint APIs to authenticate the user, and falls back to password
@@ -229,8 +233,9 @@ public class FragmentFingerprint extends Fragment
                 @Override
                 public void onAnimationEnd(Animator animation) {
                     super.onAnimationEnd(animation);
-                    if (getActivity() != null)
-                    getActivity().getFragmentManager().beginTransaction().remove(FragmentFingerprint.this).commit();
+                    if (getActivity() != null) {
+                        fingerPrintLayout.clearAnimation();
+                    }
                 }
             });
 

--- a/app/src/main/java/com/breadwallet/presenter/fragments/FragmentFingerprint.java
+++ b/app/src/main/java/com/breadwallet/presenter/fragments/FragmentFingerprint.java
@@ -65,11 +65,11 @@ public class FragmentFingerprint extends Fragment
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
 
-        View v = inflater.inflate(R.layout.fingerprint_dialog_container, container, false);
-        message = (TextView) v.findViewById(R.id.fingerprint_description);
-        title = (TextView) v.findViewById(R.id.fingerprint_title);
-        fingerPrintLayout = (LinearLayout) v.findViewById(R.id.fingerprint_layout);
-        fingerprintBackground = (RelativeLayout) v.findViewById(R.id.fingerprint_background);
+        View authModalView = inflater.inflate(R.layout.fingerprint_dialog_container, container, false);
+        message = (TextView) authModalView.findViewById(R.id.fingerprint_description);
+        title = (TextView) authModalView.findViewById(R.id.fingerprint_title);
+        fingerPrintLayout = (LinearLayout) authModalView.findViewById(R.id.fingerprint_layout);
+        fingerprintBackground = (RelativeLayout) authModalView.findViewById(R.id.fingerprint_background);
         Bundle bundle = getArguments();
         String titleString = bundle.getString("title");
         String messageString = bundle.getString("message");
@@ -83,12 +83,12 @@ public class FragmentFingerprint extends Fragment
         }
         FingerprintManager mFingerprintManager = (FingerprintManager) getActivity().getSystemService(Activity.FINGERPRINT_SERVICE);
         mFingerprintUiHelperBuilder = new FingerprintUiHelper.FingerprintUiHelperBuilder(mFingerprintManager);
-        mFingerprintUiHelper = mFingerprintUiHelperBuilder.build((ImageView) v.findViewById(R.id.fingerprint_icon),
-                (TextView) v.findViewById(R.id.fingerprint_status), this, getContext());
-        View mFingerprintContent = v.findViewById(R.id.fingerprint_container);
+        mFingerprintUiHelper = mFingerprintUiHelperBuilder.build((ImageView) authModalView.findViewById(R.id.fingerprint_icon),
+                (TextView) authModalView.findViewById(R.id.fingerprint_status), this, getContext());
+        View mFingerprintContent = authModalView.findViewById(R.id.fingerprint_container);
 
-        Button mCancelButton = (Button) v.findViewById(R.id.cancel_button);
-        Button mSecondDialogButton = (Button) v.findViewById(R.id.second_dialog_button);
+        Button mCancelButton = (Button) authModalView.findViewById(R.id.cancel_button);
+        Button mSecondDialogButton = (Button) authModalView.findViewById(R.id.second_dialog_button);
         mCancelButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
@@ -108,7 +108,7 @@ public class FragmentFingerprint extends Fragment
             }
         });
 
-        return v;
+        return authModalView;
     }
 
     @Override
@@ -223,12 +223,14 @@ public class FragmentFingerprint extends Fragment
             fingerPrintLayout.animate()
                     .translationY(1500)
                     .setDuration(ANIMATION_DURATION)
-                    .withLayer().setInterpolator(new AnticipateInterpolator(2f)).setListener(new AnimatorListenerAdapter() {
+                    .withLayer()
+                    .setInterpolator(new AnticipateInterpolator(2.0f))
+                    .setListener(new AnimatorListenerAdapter() {
                 @Override
                 public void onAnimationEnd(Animator animation) {
                     super.onAnimationEnd(animation);
                     if (getActivity() != null)
-                        getActivity().getFragmentManager().beginTransaction().remove(FragmentFingerprint.this).commit();
+                    getActivity().getFragmentManager().beginTransaction().remove(FragmentFingerprint.this).commit();
                 }
             });
 

--- a/app/src/main/java/com/breadwallet/presenter/fragments/FragmentFingerprint.java
+++ b/app/src/main/java/com/breadwallet/presenter/fragments/FragmentFingerprint.java
@@ -1,19 +1,4 @@
-package com.breadwallet.presenter.fragments;/*
- * Copyright (C) 2015 The Android Open Source Project 
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
- * You may obtain a copy of the License at 
- * 
- *      http://www.apache.org/licenses/LICENSE-2.0 
- * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
- * limitations under the License 
- */
-
+package com.breadwallet.presenter.fragments;
 import android.animation.Animator;
 import android.animation.AnimatorListenerAdapter;
 import android.animation.ArgbEvaluator;
@@ -45,7 +30,6 @@ import com.breadwallet.tools.security.AuthManager;
 import com.breadwallet.tools.security.FingerprintUiHelper;
 import com.breadwallet.tools.util.Utils;
 
-
 /**
  * A dialog which uses fingerprint APIs to authenticate the user, and falls back to password
  * authentication if fingerprint is not available.
@@ -74,10 +58,7 @@ public class FragmentFingerprint extends Fragment
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-
-        // Do not create a new Fragment when the Activity is re-created such as orientation changes. 
         setRetainInstance(true);
-//        setStyle(DialogFragment.STYLE_NORMAL, android.R.style.Theme_Material_Light_Dialog);
     }
 
     @Override
@@ -85,7 +66,6 @@ public class FragmentFingerprint extends Fragment
                              Bundle savedInstanceState) {
 
         View v = inflater.inflate(R.layout.fingerprint_dialog_container, container, false);
-//        getDialog().setTitle(R.string.fingerprint_auth);
         message = (TextView) v.findViewById(R.id.fingerprint_description);
         title = (TextView) v.findViewById(R.id.fingerprint_title);
         fingerPrintLayout = (LinearLayout) v.findViewById(R.id.fingerprint_layout);
@@ -113,11 +93,6 @@ public class FragmentFingerprint extends Fragment
             @Override
             public void onClick(View view) {
                 if (!BRAnimator.isClickAllowed()) return;
-//                if (!BRAnimator.scanResultFragmentOn && mode == BRConstants.AUTH_FOR_PAY && request.isAmountRequested) {
-////                    FragmentScanResult.address = request.address[0];
-//                    BRWalletManager.getInstance().offerToChangeTheAmount(getActivity(), "");
-//                }
-//                dismiss();
                 closeMe();
             }
         });

--- a/app/src/main/java/com/breadwallet/presenter/fragments/FragmentFingerprint.java
+++ b/app/src/main/java/com/breadwallet/presenter/fragments/FragmentFingerprint.java
@@ -28,8 +28,10 @@ import com.breadwallet.presenter.activities.BreadActivity;
 import com.breadwallet.presenter.interfaces.BRAuthCompletion;
 import com.breadwallet.tools.animation.BRAnimator;
 import com.breadwallet.tools.animation.DecelerateOvershootInterpolator;
+import com.breadwallet.tools.manager.AnalyticsManager;
 import com.breadwallet.tools.security.AuthManager;
 import com.breadwallet.tools.security.FingerprintUiHelper;
+import com.breadwallet.tools.util.BRConstants;
 import com.breadwallet.tools.util.Utils;
 
 import timber.log.Timber;
@@ -235,6 +237,7 @@ public class FragmentFingerprint extends Fragment
                     super.onAnimationEnd(animation);
                     if (getActivity() != null) {
                         fingerPrintLayout.clearAnimation();
+                        AnalyticsManager.logCustomEvent(BRConstants._20230131_NENR);
                     }
                 }
             });

--- a/app/src/main/java/com/breadwallet/presenter/fragments/FragmentFingerprint.java
+++ b/app/src/main/java/com/breadwallet/presenter/fragments/FragmentFingerprint.java
@@ -137,9 +137,8 @@ public class FragmentFingerprint extends Fragment
     @Override
     public void onStop() {
         super.onStop();
-
-        animateBackgroundDim(true);
-        animateSignalSlide(true);
+//        animateBackgroundDim(true);
+//        animateSignalSlide(true);
         if (!authSucceeded)
             completion.onCancel();
     }

--- a/app/src/main/java/com/breadwallet/presenter/fragments/FragmentMenu.java
+++ b/app/src/main/java/com/breadwallet/presenter/fragments/FragmentMenu.java
@@ -53,7 +53,6 @@ public class FragmentMenu extends Fragment {
         background.setOnClickListener(v -> {
             if (!BRAnimator.isClickAllowed()) return;
             closeMenu();
-            getActivity().onBackPressed();
         });
 
         itemList = new ArrayList<>();
@@ -82,21 +81,18 @@ public class FragmentMenu extends Fragment {
         itemList.add(new BRMenuItem(getString(R.string.MenuButton_lock), R.drawable.ic_lock, v -> {
             closeMenu();
             final Activity from = getActivity();
-            from.getFragmentManager().popBackStack();
             BRAnimator.startBreadActivity(from, true);
         }));
 
         /* Close button*/
         rootView.findViewById(R.id.close_button).setOnClickListener(v -> {
             closeMenu();
-            Activity app = getActivity();
-            app.getFragmentManager().popBackStack();
         });
 
         mTitle = rootView.findViewById(R.id.title);
         mListView = rootView.findViewById(R.id.menu_listview);
         mListView.setAdapter(new MenuListAdapter(getContext(), R.layout.menu_list_item, itemList));
-        signalLayout.setOnTouchListener(new SlideDetector(getContext(), signalLayout));
+        signalLayout.setOnTouchListener(new SlideDetector(signalLayout, this::closeMenu));
 
         return rootView;
     }
@@ -154,7 +150,7 @@ public class FragmentMenu extends Fragment {
     private void closeMenu() {
         BRAnimator.animateBackgroundDim(background, true);
         BRAnimator.animateSignalSlide(signalLayout, true, () -> {
-            if (getActivity() != null) {
+            if (getActivity() != null && !getActivity().isDestroyed() && !getActivity().isFinishing()) {
                 getActivity().getFragmentManager().popBackStack();
             }
         });

--- a/app/src/main/java/com/breadwallet/presenter/fragments/FragmentPin.java
+++ b/app/src/main/java/com/breadwallet/presenter/fragments/FragmentPin.java
@@ -204,22 +204,22 @@ public class FragmentPin extends Fragment {
     @Override
     public void onStop() {
         super.onStop();
-        keyboard.animate()
-                .translationY(1000)
-                .withLayer();
-        dialogLayout.animate()
-                .scaleY(0)
-                .scaleX(0).alpha(0);
-        mainLayout.animate().alpha(0);
-        if (!authSucceeded)
-            completion.onCancel();
-        new Handler().postDelayed(new Runnable() {
-            @Override
-            public void run() {
-                if (getActivity() != null)
-                    getActivity().getFragmentManager().beginTransaction().remove(FragmentPin.this).commit();
-            }
-        }, 1000);
+//        keyboard.animate()
+//                .translationY(1000)
+//                .withLayer();
+//        dialogLayout.animate()
+//                .scaleY(0)
+//                .scaleX(0).alpha(0);
+//        mainLayout.animate().alpha(0);
+//        if (!authSucceeded)
+//            completion.onCancel();
+//        new Handler().postDelayed(new Runnable() {
+//            @Override
+//            public void run() {
+//                if (getActivity() != null)
+//                    getActivity().getFragmentManager().beginTransaction().remove(FragmentPin.this).commit();
+//            }
+//        }, 1000);
     }
 
     public void setCompletion(BRAuthCompletion completion) {

--- a/app/src/main/java/com/breadwallet/presenter/fragments/FragmentSend.kt
+++ b/app/src/main/java/com/breadwallet/presenter/fragments/FragmentSend.kt
@@ -118,7 +118,7 @@ class FragmentSend : Fragment() {
         isoText.textSize = 18f
         isoText.setTextColor(requireContext().getColor(R.color.light_gray))
         isoText.requestLayout()
-        signalLayout.setOnTouchListener(SlideDetector(context, signalLayout))
+        signalLayout.setOnTouchListener(SlideDetector(signalLayout) { animateClose() })
         AnalyticsManager.logCustomEvent(BRConstants._20191105_VSC)
         setupFeesSelector(rootView)
         showFeeSelectionButtons(feeButtonsShown)
@@ -449,10 +449,10 @@ class FragmentSend : Fragment() {
         })
         backgroundLayout.setOnClickListener(View.OnClickListener {
             if (!BRAnimator.isClickAllowed()) return@OnClickListener
-            requireActivity().onBackPressed()
+            animateClose()
         })
         close.setOnClickListener {
-            activity?.onBackPressed()
+            animateClose()
         }
         addressEdit.setOnEditorActionListener { _, actionId, event ->
             if (event != null && event.keyCode == KeyEvent.KEYCODE_ENTER || actionId == EditorInfo.IME_ACTION_DONE || actionId == EditorInfo.IME_ACTION_NEXT) {
@@ -733,6 +733,16 @@ class FragmentSend : Fragment() {
                 amountEdit.performClick()
                 updateText()
             }, 500)
+        }
+    }
+
+    private fun animateClose() {
+        BRAnimator.animateBackgroundDim(backgroundLayout, true)
+        BRAnimator.animateSignalSlide(signalLayout, true) { close() }
+    }
+    private fun close() {
+        if(activity != null && activity?.isFinishing != true) {
+            activity?.onBackPressed()
         }
     }
 

--- a/app/src/main/java/com/breadwallet/presenter/fragments/FragmentTransactionDetails.java
+++ b/app/src/main/java/com/breadwallet/presenter/fragments/FragmentTransactionDetails.java
@@ -3,9 +3,6 @@ package com.breadwallet.presenter.fragments;
 import android.app.Activity;
 import android.app.Fragment;
 import android.os.Bundle;
-import androidx.annotation.Nullable;
-import androidx.viewpager.widget.ViewPager;
-import android.util.Log;
 import android.util.TypedValue;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -13,6 +10,9 @@ import android.view.ViewGroup;
 import android.view.ViewTreeObserver;
 import android.widget.LinearLayout;
 import android.widget.TextView;
+
+import androidx.annotation.Nullable;
+import androidx.viewpager.widget.ViewPager;
 
 import com.breadwallet.R;
 import com.breadwallet.presenter.entities.TxItem;
@@ -61,7 +61,6 @@ public class FragmentTransactionDetails extends Fragment {
         return rootView;
     }
 
-
     @Override
     public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
@@ -70,40 +69,24 @@ public class FragmentTransactionDetails extends Fragment {
         observer.addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
             @Override
             public void onGlobalLayout() {
-                if(observer.isAlive()) {
+                if (observer.isAlive()) {
                     observer.removeOnGlobalLayoutListener(this);
                 }
                 BRAnimator.animateBackgroundDim(backgroundLayout, false);
                 BRAnimator.animateSignalSlide(txViewPager, false, null);
             }
         });
-
     }
 
-    @Override
-    public void onStop() {
-        super.onStop();
+    public void close() {
         final Activity app = getActivity();
         BRAnimator.animateBackgroundDim(backgroundLayout, true);
-        BRAnimator.animateSignalSlide(txViewPager, true, new BRAnimator.OnSlideAnimationEnd() {
-            @Override
-            public void onAnimationEnd() {
-                if (app != null && !app.isDestroyed())
-                    app.getFragmentManager().popBackStack();
-                else
-                    Timber.d("onAnimationEnd: app is null");
-            }
+        BRAnimator.animateSignalSlide(txViewPager, true, () -> {
+            if (app != null && !app.isFinishing())
+                app.getFragmentManager().popBackStack();
+            else
+                Timber.d("onAnimationEnd: app is null");
         });
-    }
-
-    @Override
-    public void onResume() {
-        super.onResume();
-    }
-
-    @Override
-    public void onPause() {
-        super.onPause();
     }
 
     public void setItems(List<TxItem> items) {

--- a/app/src/main/java/com/breadwallet/tools/animation/SlideDetector.java
+++ b/app/src/main/java/com/breadwallet/tools/animation/SlideDetector.java
@@ -2,25 +2,24 @@ package com.breadwallet.tools.animation;
 
 import android.animation.Animator;
 import android.animation.AnimatorListenerAdapter;
-import android.app.Activity;
-import android.content.Context;
-import android.util.Log;
 import android.view.MotionEvent;
 import android.view.View;
-import android.view.ViewTreeObserver;
 import android.view.animation.OvershootInterpolator;
 
 public class SlideDetector implements View.OnTouchListener {
 
-    private static final String TAG = SlideDetector.class.getName();
+    public interface SlideDetectorEvent {
+        void onClosed();
+    }
 
-    private Context context;
+    private static final String TAG = SlideDetector.class.getName();
     private View _root;
     float origY;
     float dY;
+    private SlideDetectorEvent slideDetectorEvent;
 
-    public SlideDetector(Context context, final View view) {
-        this.context = context;
+    public SlideDetector(final View view, SlideDetectorEvent slideDetectorEvent) {
+        this.slideDetectorEvent = slideDetectorEvent;
         _root = view;
     }
 
@@ -68,6 +67,8 @@ public class SlideDetector implements View.OnTouchListener {
     }
 
     private void removeCurrentView() {
-        ((Activity) context).getFragmentManager().popBackStack();
+        if (slideDetectorEvent != null) {
+            slideDetectorEvent.onClosed();
+        }
     }
 }

--- a/app/src/main/java/com/breadwallet/tools/security/AuthManager.java
+++ b/app/src/main/java/com/breadwallet/tools/security/AuthManager.java
@@ -214,7 +214,7 @@ public class AuthManager {
                 transaction.setCustomAnimations(0, 0, 0, R.animator.plain_300);
                 transaction.add(android.R.id.content, fingerprintFragment, FragmentFingerprint.class.getName());
                 transaction.addToBackStack(null);
-                if (!app.isDestroyed())
+                if (!app.isDestroyed() && !app.isFinishing())
                     transaction.commit();
             } else {
                 breadPin = new FragmentPin();
@@ -227,7 +227,7 @@ public class AuthManager {
                 transaction.setCustomAnimations(0, 0, 0, R.animator.plain_300);
                 transaction.add(android.R.id.content, breadPin, breadPin.getClass().getName());
                 transaction.addToBackStack(null);
-                if (!app.isDestroyed()) {
+                if (!app.isDestroyed() && !app.isFinishing()) {
                     transaction.commit();
                 }
             }

--- a/app/src/main/java/com/breadwallet/tools/util/BRConstants.java
+++ b/app/src/main/java/com/breadwallet/tools/util/BRConstants.java
@@ -153,6 +153,7 @@ public class BRConstants {
     public static final String _20210804_TAULO = "ternio_API_user_log_out";
     public static final String _20210427_HCIEEH = "heartbeat_check_if_event_even_happens";
     public static final String _20220822_UTOU = "user_tapped_on_ud";
+    public static final String _20230131_NENR = "no_error_nominal_response";
     ///Dev: These events not yet used
 
     @Retention(RetentionPolicy.SOURCE)
@@ -188,7 +189,8 @@ public class BRConstants {
             _20210804_TAULI,
             _20210804_TAULO,
             _20210427_HCIEEH,
-            _20220822_UTOU
+            _20220822_UTOU,
+            _20230131_NENR
     })
     public @interface Event {
     }


### PR DESCRIPTION
# What was wrong?
When the user has a Fingerprint reader and has it enabled, the reader needs to dismiss the modal when the action has completed. The code had a smell in that it was removing an object that likely would still be alive.
This is found in FingerprintFragment.java line (265) now 237

[Firebase Crashlytics Link](https://console.firebase.google.com/u/0/project/litewallet-beta/crashlytics/app/android:com.loafwallet/issues?state=open&time=last-seven-days&tag=all&sort=eventCount)

# What was done
Rather than remove the activity which was a top 2 Crash in the app, the animation call `fingerPrintLayout.clearAnimation()`. This is suggested as a solution here:
 https://stackoverflow.com/questions/4750939/android-animation-is-not-finished-in-onanimationend
 
Will monitor this over the next few days.

Closes #125