### PR TITLE
Bugfix - fix FragmentMenu crash in menuClose() 

### DIFF
--- a/app/src/main/java/com/breadwallet/presenter/fragments/FragmentMenu.java
+++ b/app/src/main/java/com/breadwallet/presenter/fragments/FragmentMenu.java
@@ -149,10 +149,9 @@ public class FragmentMenu extends Fragment {
 
     private void closeMenu() {
         BRAnimator.animateBackgroundDim(background, true);
-        BRAnimator.animateSignalSlide(signalLayout, true, () -> {
-            if (getActivity() != null && !getActivity().isDestroyed() && !getActivity().isFinishing()) {
-                getActivity().getFragmentManager().popBackStack();
-            }
-        });
+        BRAnimator.animateSignalSlide(signalLayout, true, () -> {});
+        if (getActivity() != null && !getActivity().isDestroyed() && !getActivity().isFinishing()) {
+            getActivity().getFragmentManager().popBackStack();
+        }
     }
 }


### PR DESCRIPTION
 - fixes IllegalStateException: Can not perform this action after onSaveInstanceState
 - https://console.firebase.google.com/project/litewallet-beta/crashlytics/app/android:com.loafwallet/issues/af7ca3c0ca61b356ae917188611bf28d