### PR TITLE
Bugfix - Phrase Reminder crash

### DIFF
--- a/app/src/main/java/com/breadwallet/presenter/fragments/FragmentBalanceSeedReminder.kt
+++ b/app/src/main/java/com/breadwallet/presenter/fragments/FragmentBalanceSeedReminder.kt
@@ -1,6 +1,7 @@
 package com.breadwallet.presenter.fragments
 
 import android.os.Bundle
+import android.security.keystore.UserNotAuthenticatedException
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -66,7 +67,9 @@ class FragmentBalanceSeedReminder : Fragment() {
         fetchSeedPhrase()
     }
     fun fetchSeedPhrase() {
-        seedPhraseTextView.text =  String(BRKeyStore.getPhrase(context, 0))
+        try {
+            seedPhraseTextView.text = String(BRKeyStore.getPhrase(context, 0))
+        } catch (_: UserNotAuthenticatedException) {}
     }
 
     private fun animateClose() {


### PR DESCRIPTION
 - added an exception handler for UserNotAuthenticatedException.
 - note: this should allow for the system to display the native authorization UI  if needed
 - fixes issue - https://console.firebase.google.com/u/0/project/litewallet-beta/crashlytics/app/android:com.loafwallet/issues/09dac17241309f0e823ef597a9a82cd4