### PR TITLE
Remove Opaque on IntroActivity

### DIFF
--- a/app/src/main/res/layout/activity_intro.xml
+++ b/app/src/main/res/layout/activity_intro.xml
@@ -3,9 +3,9 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/intro_layout"
-    android:layout_width="wrap_content"
+    android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/litecoin_litewallet_blue"
+    android:background="@color/litecoin_litewallet_dark_blue"
     android:orientation="vertical">
 
     <ImageView


### PR DESCRIPTION
Hello! 
This PR is to remove opaque on IntroActivity
Before:
![photo_2024-03-29_15-33-38](https://github.com/litecoin-foundation/litewallet-android/assets/54074780/551944dc-6524-4648-94c8-52b118327f6a)
After:
![photo_2024-03-29_15-33-28](https://github.com/litecoin-foundation/litewallet-android/assets/54074780/7a2d7b29-613b-4afb-8c0e-5920c13a71f3)
