### PR TITLE
fix: [#126] the issue came from FragmentBalanceSeedReminder.fetchSeedPhrase

### DIFF
--- a/app/src/main/java/com/breadwallet/presenter/fragments/FragmentBalanceSeedReminder.kt
+++ b/app/src/main/java/com/breadwallet/presenter/fragments/FragmentBalanceSeedReminder.kt
@@ -82,7 +82,8 @@ class FragmentBalanceSeedReminder : Fragment() {
             registerAnalyticsError("null_in_fragment_balance_fetch_seed")
         }
         else {
-            seedPhraseTextView.text =  String(BRKeyStore.getPhrase(this.activity, 0)) ?: "NO_PHRASE"
+            seedPhraseTextView.text = runCatching { BRKeyStore.getPhrase(this.activity, 0) }
+                .getOrNull()?.decodeToString() ?: "NO_PHRASE"
         }
     }
     private fun animateClose() {


### PR DESCRIPTION
# Whats Changed?

from the `crashlytics` all of source crash came from `FragmentBalanceSeedReminder.fetchSeedPhrase` that will call `BRKeyStore.getPhrase(this.activity, 0)`, for now we just wrap with `runCatching` from Kotlin or you can call it `try-catch`, [more detail](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/run-catching.html)