### PR TITLE
revert minSDkVersion to 29

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -61,7 +61,7 @@ android {
     defaultConfig {
         testInstrumentationRunner = 'androidx.test.runner.AndroidJUnitRunner'
         applicationId = 'com.loafwallet'
-        minSdkVersion 31
+        minSdkVersion 29
         targetSdkVersion 34
         versionCode 20241118
         versionName "v2.12.2"


### PR DESCRIPTION
# Description

The growth of Litewallet means older users are blocked from using the app.  This opens the range of potential users

## Notes

- [ ] If there are any known issues in SDK 29 list and recommend fixes

Closes #275 