### PR TITLE
fix: [#266] add null checking and default value based on iOS since getCurrency can produce null

### DIFF
--- a/app/src/main/java/com/breadwallet/tools/util/Utils.java
+++ b/app/src/main/java/com/breadwallet/tools/util/Utils.java
@@ -303,10 +303,6 @@ public class Utils {
     /// Description: 1715876807
     public static long tieredOpsFee(Context app, long sendAmount) {
 
-        /**
-         * current solution, add default rate based on iOS: https://github.com/litecoin-foundation/litewallet-ios/blob/9ef6ba8f9cf8ef57f3c6056c31304c6197cafa7a/litewallet/Constants/Functions.swift#L44
-         * and add null checking after `CurrencyDataSource.getInstance(app).getCurrencyByIso(usIso);`
-         */
         double doubleRate = 83.000;
         double sendAmountDouble = new Double(String.valueOf(sendAmount));
         String usIso = Currency.getInstance(new Locale("en", "US")).getCurrencyCode();

--- a/app/src/main/java/com/breadwallet/tools/util/Utils.java
+++ b/app/src/main/java/com/breadwallet/tools/util/Utils.java
@@ -303,10 +303,17 @@ public class Utils {
     /// Description: 1715876807
     public static long tieredOpsFee(Context app, long sendAmount) {
 
+        /**
+         * current solution, add default rate based on iOS: https://github.com/litecoin-foundation/litewallet-ios/blob/9ef6ba8f9cf8ef57f3c6056c31304c6197cafa7a/litewallet/Constants/Functions.swift#L44
+         * and add null checking after `CurrencyDataSource.getInstance(app).getCurrencyByIso(usIso);`
+         */
+        double doubleRate = 83.000;
         double sendAmountDouble = new Double(String.valueOf(sendAmount));
         String usIso = Currency.getInstance(new Locale("en", "US")).getCurrencyCode();
         CurrencyEntity currency = CurrencyDataSource.getInstance(app).getCurrencyByIso(usIso);
-        double doubleRate = currency.rate;
+        if (currency != null) {
+            doubleRate = currency.rate;
+        }
         double usdInLTC = sendAmountDouble * doubleRate / 100_000_000.0;
         usdInLTC = Math.floor(usdInLTC * 100) / 100;
 


### PR DESCRIPTION
# Overview
Previous implementation didn't have default value, for example if first time user want to do transaction then the local value didn't exists it will return null, [check this](https://github.com/litecoin-foundation/litewallet-android/blob/98bcc4a594610219a11dd3528991ea24fa6951a7/app/src/main/java/com/breadwallet/tools/sqlite/CurrencyDataSource.java#L91-L110).
add default value based on iOS [here](https://github.com/litecoin-foundation/litewallet-ios/blob/9ef6ba8f9cf8ef57f3c6056c31304c6197cafa7a/litewallet/Constants/Functions.swift#L44)