### PR TITLE
fix: just close the FragmentRequestAmount if refreshAddress return false

### DIFF
--- a/app/src/main/java/com/breadwallet/presenter/fragments/FragmentRequestAmount.java
+++ b/app/src/main/java/com/breadwallet/presenter/fragments/FragmentRequestAmount.java
@@ -236,7 +236,7 @@ public class FragmentRequestAmount extends Fragment {
             @Override
             public void run() {
                 boolean success = BRWalletManager.refreshAddress(getActivity());
-                if (!success) throw new RuntimeException("failed to retrieve address");
+                if (!success) close();
 
                 receiveAddress = BRSharedPrefs.getReceiveAddress(getActivity());
 


### PR DESCRIPTION
## Overview
Just close the `FragmentRequestAmount` when the `refreshAddress` return `false`

## Issue
https://github.com/litecoin-foundation/litewallet-engineering/issues/8