### PR TITLE
fix: fix crash android.os.NetworkOnMainThreadException: onPublishTxAuth

### DIFF
--- a/app/src/main/java/com/breadwallet/tools/security/BRSender.java
+++ b/app/src/main/java/com/breadwallet/tools/security/BRSender.java
@@ -288,18 +288,10 @@ public class BRSender {
                 BRExecutor.getInstance().forMainThreadTasks().execute(new Runnable() {
                     @Override
                     public void run() {
-                        PostAuth.getInstance().onPublishTxAuth(ctx, false);
-                        BRExecutor.getInstance().forMainThreadTasks().execute(new Runnable() {
-                            @Override
-                            public void run() {
-                                BRAnimator.killAllFragments((FragmentActivity) ctx);
-                                BRAnimator.startBreadIfNotStarted((Activity) ctx);
-                            }
-                        });
-
+                        BRAnimator.killAllFragments((FragmentActivity) ctx);
+                        BRAnimator.startBreadIfNotStarted((Activity) ctx);
                     }
                 });
-
             }
         });
 


### PR DESCRIPTION
## Overview
when we remove `AuthManager.getInstance().authPrompt`, maybe have conflict at that time and resolved with existing code that duplicated.

